### PR TITLE
Refactor to keep core-types framework agnostic

### DIFF
--- a/src/components/Space.tsx
+++ b/src/components/Space.tsx
@@ -1,5 +1,5 @@
-import { ISpaceProps, CenterType, ResizeHandlePlacement, AnchorType } from "../core-types";
-import { useSpace, ParentContext, LayerContext, DOMRectContext } from "../core-react";
+import { CenterType, ResizeHandlePlacement, AnchorType } from "../core-types";
+import { useSpace, ParentContext, LayerContext, DOMRectContext, IReactSpaceProps } from "../core-react";
 import * as React from "react";
 import { Centered } from "./Centered";
 import { CenteredVertically } from "./CenteredVertically";
@@ -15,13 +15,13 @@ function applyCentering(children: React.ReactNode, centerType: CenterType | unde
 	return children;
 }
 
-export class Space extends React.Component<ISpaceProps> {
+export class Space extends React.Component<IReactSpaceProps> {
 	public render() {
 		return <SpaceInner {...this.props} wrapperInstance={this} />;
 	}
 }
 
-const SpaceInner: React.FC<ISpaceProps & { wrapperInstance: Space }> = (props) => {
+const SpaceInner: React.FC<IReactSpaceProps & { wrapperInstance: Space }> = (props) => {
 	if (!props.id && !props.wrapperInstance["_react_spaces_uniqueid"]) {
 		props.wrapperInstance["_react_spaces_uniqueid"] = `s${shortuuid()}`;
 	}

--- a/src/core-react.ts
+++ b/src/core-react.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { createStore } from "./core";
-import { ISpaceProps, ISpaceStore, ISpaceDefinition, IPositionalProps, ResizeType, CenterType } from "./core-types";
+import { ISpaceProps, ISpaceStore, ISpaceDefinition, IPositionalProps, ResizeType, CenterType, ICommonProps } from "./core-types";
 import { coalesce, shortuuid } from "./core-utils";
 import { ResizeSensor } from "css-element-queries";
 import * as PropTypes from "prop-types";
@@ -30,10 +30,6 @@ export const commonProps = {
 	onTouchEnd: PropTypes.func,
 };
 
-export interface IReactSpacesOptions {
-	debug?: boolean
-}
-
 export interface IReactEvents {
 	onClick?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
 	onDoubleClick?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
@@ -46,6 +42,15 @@ export interface IReactEvents {
 	onTouchEnd?: (event: React.TouchEvent<HTMLElement>) => void;
 }
 
+export interface IReactSpaceProps extends ISpaceProps, IReactEvents {
+	style?: React.CSSProperties;
+	as?: keyof React.ReactDOM | React.ComponentType<ICommonProps>;
+}
+
+export interface IReactSpacesOptions {
+	debug?: boolean;
+}
+
 export function useForceUpdate() {
 	const [, setTick] = React.useState(0);
 	const update = React.useCallback(() => {
@@ -54,7 +59,7 @@ export function useForceUpdate() {
 	return update;
 }
 
-export function useSpace(props: ISpaceProps) {
+export function useSpace(props: IReactSpaceProps) {
 	const store = currentStore;
 	const update = useForceUpdate();
 	const parent = React.useContext(ParentContext);
@@ -179,6 +184,6 @@ export function useSpaceResizeHandles(store: ISpaceStore, space: ISpaceDefinitio
 	}
 
 	return {
-		mouseHandles
+		mouseHandles,
 	};
 }

--- a/src/core-types.ts
+++ b/src/core-types.ts
@@ -1,5 +1,3 @@
-import React from "react";
-
 export enum Type {
 	ViewPort = "viewport",
 	Fixed = "fixed",
@@ -46,23 +44,9 @@ export enum CenterType {
 	HorizontalVertical = "horizontalVertical",
 }
 
-export interface IPassThroughEvents {
-	onClick?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
-	onDoubleClick?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
-	onMouseDown?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
-	onMouseEnter?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
-	onMouseLeave?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
-	onMouseMove?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
-	onTouchStart?: (event: React.TouchEvent<HTMLElement>) => void;
-	onTouchMove?: (event: React.TouchEvent<HTMLElement>) => void;
-	onTouchEnd?: (event: React.TouchEvent<HTMLElement>) => void;
-}
-
-export interface ICommonProps extends IPassThroughEvents {
+export interface ICommonProps {
 	id?: string;
 	className?: string;
-	style?: React.CSSProperties;
-	as?: keyof React.ReactDOM | React.ComponentType<ICommonProps>;
 	centerContent?: CenterType;
 	zIndex?: number;
 	scrollable?: boolean;


### PR DESCRIPTION
Slight modification to remove React specific types/references from core-types